### PR TITLE
Refactor `rendering.rb` to not use `alias_method_chain`

### DIFF
--- a/lib/prototype-rails/rendering.rb
+++ b/lib/prototype-rails/rendering.rb
@@ -1,13 +1,27 @@
 require 'action_view/helpers/rendering_helper'
 
 ActionView::Helpers::RenderingHelper.module_eval do
-  def render_with_update(options = {}, locals = {}, &block)
-    if options == :update
-      update_page(&block)
-    else
-      render_without_update(options, locals, &block)
+  if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 0
+    module RenderWithUpdate
+      def render(options = {}, locals = {}, &block)
+        if options == :update
+          update_page(&block)
+        else
+          super(options, locals, &block)
+        end
+      end
     end
+
+    prepend RenderWithUpdate
+  else
+    def render_with_update(options = {}, locals = {}, &block)
+      if options == :update
+        update_page(&block)
+      else
+        render_without_update(options, locals, &block)
+      end
+    end
+
+    alias_method_chain :render, :update
   end
-  
-  alias_method_chain :render, :update
 end

--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = 'prototype-rails'
-  spec.version  = '4.0.0'
+  spec.version  = '4.1.0'
   spec.summary  = 'Prototype, Scriptaculous, and RJS for Ruby on Rails'
   spec.homepage = 'http://github.com/rails/prototype-rails'
   spec.author   = 'Xavier Noria'


### PR DESCRIPTION
* Rails 5.x has deprecated `alias_method_chain`, in favor of
	`Module.prepend`